### PR TITLE
.NET Core 3.1 & year-less invalid dates

### DIFF
--- a/src/DeploymentGates.UnitTests/DeploymentGates.UnitTests.csproj
+++ b/src/DeploymentGates.UnitTests/DeploymentGates.UnitTests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DeploymentGates.UnitTests/TimeBasedArgsUnitTests.cs
+++ b/src/DeploymentGates.UnitTests/TimeBasedArgsUnitTests.cs
@@ -50,11 +50,11 @@ namespace DeploymentGates.UnitTests
             string json = @"
 {
   'startTimeSpan': '12:30',
-  'endTimeSpan': '17:00',
-  'timeZoneId': 'Eastern Standard Time'
+  'endTimeSpan': '19:00',
+  'timeZoneId': 'UTC'
 }";
             TimeBasedArgs args = TimeBasedArgs.FromJson(json);
-            Assert.True(args.IsInsideWindow(DateTime.Parse("7/22/2019 18:00:00Z")));
+            Assert.True(args.IsInsideWindow(DateTime.Parse("7/22/2019 17:59:00Z")));
             Assert.False(args.IsInsideWindow(DateTime.Parse("7/22/2019 1:00:00Z")));
         }
 
@@ -113,6 +113,32 @@ namespace DeploymentGates.UnitTests
 }";
             TimeBasedArgs args = TimeBasedArgs.FromJson(json);
             Assert.True(args.IsValidDate(DateTime.Parse("7/22/2019 18:00:00Z")));
+        }
+
+        [Fact]
+        public void IsValidDate_ParcialInvalidDates()
+        {
+            string json = @"
+{
+  'timeZoneId': 'Eastern Standard Time',
+  'validDaysOfWeek': [ 'Monday' ],
+  'invalidDates': [
+		'7/22/9999', '7/23/9999'
+	]
+}";
+            TimeBasedArgs args = TimeBasedArgs.FromJson(json);
+
+
+            int currentYear = DateTime.UtcNow.Year;
+            int previousYear = DateTime.UtcNow.Year - 1;
+
+            Assert.True(args.IsValidDate(DateTime.Parse($"7/24/{previousYear} 18:00:00Z")));
+            Assert.True(args.IsValidDate(DateTime.Parse($"7/24/{currentYear} 18:00:00Z")));
+
+            Assert.True(args.IsValidDate(DateTime.Parse($"7/22/{previousYear} 18:00:00Z")));
+            Assert.False(args.IsValidDate(DateTime.Parse($"7/22/{currentYear} 18:00:00Z")));
+            Assert.True(args.IsValidDate(DateTime.Parse($"7/23/{previousYear} 18:00:00Z")));
+            Assert.False(args.IsValidDate(DateTime.Parse($"7/23/{currentYear} 18:00:00Z")));
         }
     }
 }

--- a/src/DeploymentGates/DateTimeGates.cs
+++ b/src/DeploymentGates/DateTimeGates.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using DeploymentGates.Models;
 using System.Linq;
 
@@ -58,7 +57,7 @@ namespace DeploymentGates
 
             // Determine if the datetime is valid.
             bool isInsideTimeWindow = args.IsInsideWindow(localTime);
-            bool isValidDayOfWeek = (args.ValidDaysOfWeek.Count() == 0 || args.IsValidDayOfWeek(localTime));
+            bool isValidDayOfWeek = !args.ValidDaysOfWeek.Any() || args.IsValidDayOfWeek(localTime);
             bool isValidDate = args.IsValidDate(localTime);
 
             /// Log data

--- a/src/DeploymentGates/DeploymentGates.csproj
+++ b/src/DeploymentGates/DeploymentGates.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.8" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Also did some R# cleanups, fixed a broken test and added a new test for this new feature